### PR TITLE
Switch from REST to query params for anchoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,6 @@ npm run dev # Development mode with live data
 npm run prod # Production mode with live data
 ```
 
-## Action Items
-- Node process automatically restarts on board errors, but we should still probably have some bash automation.
-- Moving EWS API to Slalom AWS instance and authenticating without using a real person's account
-- Improve hardware
-  - Better lighting, nicer cases
-- Configuring Raspi to host and run program on Hackathon access point
-- Place a demo unit on 53
-
 ## Configuration
 
 - Raspberry Pi 2 Model B v1.1 running JESSIE (other models and distros likely work, but are untested)
@@ -112,3 +104,22 @@ Example of a `environment/room-coordinates.json` file configured to display Bron
   }
 }
 ```
+
+### Ping API
+*Alexa, where is Wrigleyville?*
+
+*Wrigleyville is on the east side of the office. I've highlighted it on map for you.*
+
+The Ping API allows services to "ping" specific rooms. Pings must be directed to specific clients that "anchored" to a particular id. The id used is completely arbitrary, but must be matched between the service making the ping and the client attempting to be pinged.
+
+To "anchor" a client, simply add an `anchor` query paramter to its route. E.g., `http://hostname:3000/two-prudential?anchor=east-lobby` defines the client's anchor as `east-lobby`.
+
+To ping this client, direct a POST request to `http://hostname:3000/api/ping` with the headers:
+
+```
+{
+  id: wrigleyville,
+  anchor: east-lobby
+}
+```
+The result of this ping is that Wrigleyville lights up on the client anchored to the east lobby. An example use of this is anchoring a client on the east lobby piTV, and assigning the nearby Amazon Echo to highlight queried rooms on the TV.

--- a/client/components/layout/controller.jsx
+++ b/client/components/layout/controller.jsx
@@ -64,11 +64,12 @@ class LayoutController extends Component {
   }
 
   handleChangeLocation(newIndex) {
-    const { layout, params } = this.props;
+    const { layout, location } = this.props;
+    const { anchor } = location.query;
     const { meetingRooms } = layout.toJS();
     const locations = pluckLocations(meetingRooms);
 
-    updateLocationIndex(locations[newIndex], params.id);
+    updateLocationIndex(locations[newIndex], anchor);
   }
 
   renderMeetingRoom(meetingRoom) {

--- a/client/components/navigation/controller.jsx
+++ b/client/components/navigation/controller.jsx
@@ -18,6 +18,7 @@ import { styles } from './styles';
 
 const NavigationController = (props) => {
   const { actions, navigation, locations, params } = props;
+  const { anchor } = props.location.query;
   const { siteNavOpen, locationModalOpen } = navigation.toJS();
   const toggleSiteNav = actions.emitSiteNavToggle.bind(null, !siteNavOpen);
   const toggleLocationModal = actions.emitLocationModalToggle.bind(null, !locationModalOpen);
@@ -27,7 +28,7 @@ const NavigationController = (props) => {
       key={`${location}-${index}`}
       label={formatForDisplay(location)}
       value={locations.indexOf(location)}
-      onClick={actions.emitLocationIndexUpdate.bind(null, location, params.id)}
+      onClick={actions.emitLocationIndexUpdate.bind(null, location, anchor)}
       style={styles.toolbarTab}/>
   );
 

--- a/client/components/navigation/location-modal.jsx
+++ b/client/components/navigation/location-modal.jsx
@@ -15,6 +15,7 @@ const LocationModal = (props) => {
           navigation,
           locations,
           toggleLocationModal } = props;
+  const { anchor } = props.location.query;
   const { siteNavOpen, locationModalOpen } = navigation.toJS();
 
   const handleLocationSelection = (location, anchorId) => {
@@ -28,7 +29,7 @@ const LocationModal = (props) => {
       key={index}
       value={index}
       primaryText={formatForDisplay(location)}
-      onClick={handleLocationSelection.bind(null, location, params.id)}/>
+      onClick={handleLocationSelection.bind(null, location, anchor)}/>
   );
 
   const buttons = [

--- a/client/utils/rooms.js
+++ b/client/utils/rooms.js
@@ -32,7 +32,7 @@ export const getLocationBackdrop = (location) => {
  * @returns {undefined}
  */
 export const updateLocationIndex = (newLocation, anchorId) => {
-  const anchor = anchorId ? `/anchor/${anchorId}` : '';
+  const anchor = anchorId ? `?anchor=${anchorId}` : '';
 
   history.push(`/${newLocation}${anchor}`);
 };
@@ -87,9 +87,9 @@ export const pluckLocations = (rooms) => {
  * @returns {string} Parsed anchor parameter.
  */
 export const getAnchor = (store) => {
-  const { pathname } = get(store.getState(), 'routeReducer.location');
+  const { anchor } = get(store.getState(), 'routeReducer.location.query');
 
-  return pathname.replace(ANCHOR_PATH_REGEX, '');
+  return anchor.replace(ANCHOR_PATH_REGEX, '');
 };
 
 /**

--- a/server/controllers/pings.js
+++ b/server/controllers/pings.js
@@ -10,7 +10,7 @@ const rooms = store().getState().roomsReducer;
 
 const pingsController = {
   handlePing(req, res) {
-    const { id, anchor } = req.params;
+    const { id, anchor } = req.headers;
     const room = find(rooms, { id });
 
     if (room) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,7 +7,7 @@ import pingsController from '../controllers/pings';
 const router = express.Router();
 
 /* Room pings */ // TODO change to use payload
-router.post('/api/ping/:id/from/:anchor', (req, res) => pingsController.handlePing(req, res));
+router.post('/api/ping', (req, res) => pingsController.handlePing(req, res));
 
 /* Map markers */
 router.post('/api/mark/:TODO', () => {


### PR DESCRIPTION
New route for anchoring clients.

```
host:3000/two-prudential-51?anchor=east-lobby
// => Anchors client to 'east lobby'
```

New API for pinging rooms.

POST: `/api/ping`
Headers:
```
{
  id: wrigleyville
  anchor: east-lobby
}
// => Sends ping for Wrigleyville to any client anchored to 'east lobby'.
```