### PR TITLE
Soi 32/implement test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ npm run test
 ```bash
 npm run test-cov
 ```
+Runs client test coverage, then server test coverage immediately after.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://img.shields.io/travis/Nase00/gtfo/master.svg?style=flat-square)](https://travis-ci.org/Nase00/gtfo) 
-[![Dependencies Status](https://david-dm.org/nase00/gtfo.svg?style=flat-square)](https://david-dm.org/nase00/gtfo) 
-[![DevDependencies Status](https://david-dm.org/nase00/gtfo/dev-status.svg?style=flat-square)](https://david-dm.org/nase00/gtfo#info=devDependencies) 
-[![Known Vulnerabilities](https://snyk.io/test/github/nase00/gtfo/badge.svg?style=flat-square)](https://snyk.io/test/github/nase00/gtfo) 
+[![Build Status](https://img.shields.io/travis/Nase00/gtfo/master.svg?style=flat-square)](https://travis-ci.org/Nase00/gtfo)
+[![Dependencies Status](https://david-dm.org/nase00/gtfo.svg?style=flat-square)](https://david-dm.org/nase00/gtfo)
+[![DevDependencies Status](https://david-dm.org/nase00/gtfo/dev-status.svg?style=flat-square)](https://david-dm.org/nase00/gtfo#info=devDependencies)
+[![Known Vulnerabilities](https://snyk.io/test/github/nase00/gtfo/badge.svg?style=flat-square)](https://snyk.io/test/github/nase00/gtfo)
 [![GitHub Release](https://img.shields.io/github/release/Nase00/gtfo.svg?style=flat-square)](https://github.com/Nase00/gtfo/releases)
 
 *This project is still in early development!*
@@ -17,7 +17,7 @@ npm run hot -- --mocks
 ```
 This will start the application in development mode with [mock data](./server/mocks/README.md) and [hot-reloading](https://github.com/gaearon/react-transform-boilerplate).
 
-To develop with live data, set up and run [ems-wrapper](https://github.com/rishirajsingh90/ems-wrapper) on the same local machine.
+To develop with live data, set up and run [ems-wrapper](https://github.com/rishirajsingh90/ews-wrapper) on the same local machine.
 
 In production mode, it assumed `ems-wrapper` is deployed on another domain, defined in `/server/constants/urls.js`.
 
@@ -35,6 +35,16 @@ npm run prod # Production mode with live data (ems-wrapper must be deployed)
 ##### Disabling hot reloading
 ```bash
 npm run dev # But why would you want to?
+```
+
+##### Tests
+```bash
+npm run test
+```
+
+##### Test coverage reporter
+```bash
+npm run test-cov
 ```
 
 ## Configuration
@@ -66,17 +76,16 @@ Finally, retrieve the access tokens and device id for each Photon, and place the
 4. Create and configure a `devices.json` file in the root directory.
 5. `npm run hot`. (prod under development)
 
-
 ### Ping API
 *Alexa, where is Kerbin?*
 
 *Kerbin is on the east side of the office. I've highlighted it on map for you.*
 
-The Ping API allows services to "ping" specific rooms. Pings must be directed to specific clients that are "anchored" to a particular id. The id used is completely arbitrary, but must be matched between the service making the ping and the client attempting to be pinged.
+The Ping API allows external services to "ping" specific rooms on targetted clients. Clients can be targetted using "anchors." The anchor id used is completely arbitrary, but must be matched between the service making the ping and the client attempting to be pinged.
 
 To "anchor" a client, simply add an `anchor` query paramter to its route. E.g., `http://hostname:3000/sears-tower-251?anchor=east-lobby` defines the client's anchor as `east-lobby`.
 
-To ping this client, direct a POST request to `http://hostname:3000/api/ping` with the headers:
+To ping this client from an external service, direct a POST request to `http://hostname:3000/api/ping` with the headers:
 
 ```
 {
@@ -84,4 +93,5 @@ To ping this client, direct a POST request to `http://hostname:3000/api/ping` wi
   anchor: east-lobby
 }
 ```
-The result of this ping is that Kerbin lights up on the client anchored to the east lobby. An example use of this is anchoring a client on the east lobby piTV, and assigning the nearby Amazon Echo to highlight queried rooms on the TV.
+
+The result of this ping is that Kerbin lights up on the client anchored to the east lobby. An example use of this is anchoring a client on a display in the east lobby, and assigning a nearby Amazon Echo to highlight queried rooms on the TV.

--- a/karma.conf.base.js
+++ b/karma.conf.base.js
@@ -1,0 +1,36 @@
+module.exports = {
+  basePath: '.',
+  frameworks: ['source-map-support', 'mocha', 'sinon'],
+  reporters: ['dots'],
+  files: [
+    'tests/config.client.js'
+  ],
+  preprocessors: {
+    'tests/config.client.js': ['webpack', 'sourcemap']
+  },
+  webpack: require('./webpack.config.test'),
+  port: 9876,
+  colors: true,
+  autoWatch: true,
+  browsers: ['Chrome', 'PhantomJS'],
+  customLaunchers: {
+    Chrome_travis_ci: {
+      base: 'Chrome',
+      flags: ['--no-sandbox']
+    }
+  },
+  singleRun: true,
+  webpackServer: {
+    quiet: false,
+    noInfo: true,
+    stats: {
+      assets: false,
+      colors: true,
+      version: false,
+      hash: false,
+      timings: false,
+      chunks: false,
+      chunkModules: false
+    }
+  }
+};

--- a/karma.conf.cov.js
+++ b/karma.conf.cov.js
@@ -6,6 +6,11 @@ const base = require('./karma.conf.base');
 
 module.exports = (config) => {
   const configuration = merge(base, {
+    reporters: ['progress', 'coverage'],
+    coverageReporter: {
+      type: "text"
+    },
+    webpack: require('./webpack.config.cov'),
     logLevel: config.LOG_INFO
   });
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "yolo": "rimraf environment/mock-data.json",
     "test": "npm run clean && npm run lint && npm run test-server && npm run test-client",
     "test-client": "karma start",
-    "test-server": "mocha ./tests/server/**/*.spec.*  --compilers js:babel-core/register --require tests/config.server.js --reporter=dot",
-    "test-cov": "karma start karma.conf.cov.js"
+    "test-server": "mocha ./tests/server/**/*.spec.* --compilers js:babel-core/register --require tests/config.server.js --reporter=dot",
+    "test-client-cov": "karma start karma.conf.cov.js",
+    "test-server-cov": "istanbul cover node_modules/mocha/bin/_mocha ./tests/server/**/*.spec.* -- --compilers js:babel-core/register --require tests/config.server.js --reporter=dot",
+    "test-cov": "npm run test-client-cov && npm run test-server-cov"
   },
   "author": "Sean Owiecki",
   "contributors": [
@@ -92,8 +94,7 @@
     "eslint-plugin-react": "^4.1.0",
     "expect": "^1.14.0",
     "file-loader": "^0.8.5",
-    "istanbul": "^0.4.2",
-    "istanbul-instrumenter-loader": "^0.2.0",
+    "istanbul": "^1.0.0-alpha.2",
     "json-loader": "^0.5.4",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "yolo": "rimraf environment/mock-data.json",
     "test": "npm run clean && npm run lint && npm run test-server && npm run test-client",
     "test-client": "karma start",
-    "test-server": "mocha ./tests/server/**/*.spec.*  --compilers js:babel-core/register --require tests/config.server.js --reporter=dot"
+    "test-server": "mocha ./tests/server/**/*.spec.*  --compilers js:babel-core/register --require tests/config.server.js --reporter=dot",
+    "test-cov": "karma start karma.conf.cov.js"
   },
   "author": "Sean Owiecki",
   "contributors": [
@@ -91,9 +92,12 @@
     "eslint-plugin-react": "^4.1.0",
     "expect": "^1.14.0",
     "file-loader": "^0.8.5",
+    "istanbul": "^0.4.2",
+    "istanbul-instrumenter-loader": "^0.2.0",
     "json-loader": "^0.5.4",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.2",
+    "karma-coverage": "^0.5.5",
     "karma-mocha": "^0.2.2",
     "karma-mocha-reporter": "^2.0.0",
     "karma-phantomjs-launcher": "^1.0.0",

--- a/webpack.config.cov.js
+++ b/webpack.config.cov.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const webpack = require('webpack');
+
+const testConfig = require('./webpack.config.test');
+
+testConfig.module.postLoaders = [
+  {
+    test: /\.(js|jsx)$/,
+    exclude: /(node_modules|tests)/,
+    loader: "istanbul-instrumenter"
+  }
+];
+
+module.exports = testConfig;


### PR DESCRIPTION
Adds a new command, `npm run test-cov` to run test coverage statistics on the client and server tests.

Also, cleaned up stuff in `README.md`.