### PR TITLE
Enable client with dd

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -1,0 +1,60 @@
+{
+  "ignore": [
+    "**/deps/**",
+    "**/node_modules/**",
+    "**/thirdparty/**",
+    "**/third_party/**",
+    "**/vendor/**",
+    "**/**-min-**",
+    "**/**-min.**",
+    "**/**.min.**",
+    "**/**jquery.?(ui|effects)-*.*.?(*).?(cs|j)s",
+    "**/**jquery-*.*.?(*).?(cs|j)s",
+    "**/prototype?(*).js",
+    "**/**?(*).ts",
+    "**/mootools*.*.*.js",
+    "**/dojo.js",
+    "**/MochiKit.js",
+    "**/yahoo-*.js",
+    "**/yui*.js",
+    "**/ckeditor*.js",
+    "**/tiny_mce*.js",
+    "**/tiny_mce/?(langs|plugins|themes|utils)/**",
+    "**/MathJax/**",
+    "**/shBrush*.js",
+    "**/shCore.js",
+    "**/shLegacy.js",
+    "**/modernizr.custom.?(*).js",
+    "**/knockout-*.*.*.debug.js",
+    "**/extjs/*.js",
+    "**/extjs/*.xml",
+    "**/extjs/*.txt",
+    "**/extjs/*.html",
+    "**/extjs/*.properties",
+    "**/extjs/.sencha",
+    "**/extjs/docs/**",
+    "**/extjs/builds/**",
+    "**/extjs/cmd/**",
+    "**/extjs/examples/**",
+    "**/extjs/locale/**",
+    "**/extjs/packages/**",
+    "**/extjs/plugins/**",
+    "**/extjs/resources/**",
+    "**/extjs/src/**",
+    "**/extjs/welcome/**",
+    "bower_components/**"
+  ],
+  "test": [
+    "**/test/**",
+    "**/tests/**",
+    "**/spec/**",
+    "**/specs/**"
+  ],
+  "dependencies": {
+    "unused-ignores": [
+      "react-motion",
+      "jsonschema",
+      "foreman"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ In production mode, it assumed `ems-wrapper` is deployed on another domain, defi
 
 ##### Options
 ```bash
---mocks # Disables Outlook api in favor of using mock reservation data
---dd # Disabled devices, useful for testing client without hardware
+--mocks # Disables Outlook api in favor of using mock reservation data.
+--dd # Disables devices, useful for client testing without room module hardware.
 ```
 ##### Production
 ```bash

--- a/server/constants/urls.js
+++ b/server/constants/urls.js
@@ -5,7 +5,7 @@ const ENV_PATH = '../environment';
 const HOST = isProd ? require(ENV_PATH).config.productionHost : 'http://localhost:8080';
 const MOCKS_HOST = 'http://localhost:3000';
 const PROD_RESERVATIONS_API = '/rest/meetingRoom/lookup/';
-export const MOCK_RESERVATIONS_API = '/mocks/meetingRoom/lookup/';
+export const MOCK_RESERVATIONS_API = '/mocks/smeetingRoom/lookup/';
 
 const MOCK_RESERVATIONS = `${MOCKS_HOST}${MOCK_RESERVATIONS_API}`;
 const PROD_RESERVATIONS = `${HOST}${PROD_RESERVATIONS_API}`;

--- a/server/controllers/devices.js
+++ b/server/controllers/devices.js
@@ -23,17 +23,21 @@ import { EMIT_INIT_DEVICES,
          FETCH_ROOM_MOTION } from '../ducks/rooms';
 import { CHECK_INTERVAL } from '../constants';
 
-const { rooms } = store.getState().roomsReducer;
-
 const devicesController = {
   initialize() {
     store.dispatch({ type: EMIT_INIT_DEVICES });
 
-    if (process.env.DISABLE_DEVICES) {
-      return;
-    }
+    devicesController.getRooms().map((room) => {
+      if (process.env.DISABLE_DEVICES) {
+        /**
+         * If devices are disabled, fetch reservations earlier
+         * and exit scope before creating board objects.
+         */
+        store.dispatch({ type: FETCH_ROOM_RESERVATIONS, room });
 
-    rooms.map((room) => {
+        return;
+      }
+
       const board = registerBoard(room);
 
       board.on('ready', devicesController.connectToRoom.bind(null, board, room));
@@ -84,6 +88,8 @@ const devicesController = {
   },
 
   getRooms() {
+    const { rooms } = store.getState().roomsReducer;
+
     return rooms;
   }
 };

--- a/server/middleware/fetch-room-reservation.js
+++ b/server/middleware/fetch-room-reservation.js
@@ -4,6 +4,7 @@ import http from 'http';
 
 import { EMIT_ROOM_STATUSES_UPDATE } from '../ducks/rooms';
 import * as urls from '../constants';
+import { logFetchRoomReservationsError } from '../utils';
 
 const fetchRoomReservations = (next, action) => {
   const { room, accessories } = action;
@@ -21,11 +22,7 @@ const fetchRoomReservations = (next, action) => {
         accessories
       });
     });
-  }).on('error', ({ code }) => {
-    const errorMessage = `Failed to fetch room reservations for ${room.id}.`;
-
-    console.error(errorMessage, code);
-  });
+  }).on('error', logFetchRoomReservationsError);
 };
 
 export default fetchRoomReservations;

--- a/server/utils/logging.js
+++ b/server/utils/logging.js
@@ -118,3 +118,12 @@ export const logBoardWarning = ({ message }) => console.log(colors.bgYellow(mess
  * @returns {undefined}
  */
 export const logBoardFailure = ({ message }) => console.log(colors.bgRed(message));
+
+/**
+ * Logs room reservation failures.
+ * @params {object} data Failure object.
+ * @returns {undefined}
+ */
+export const logFetchRoomReservationsError = ({ code, message }) => {
+  console.error('Failed to fetch room reservations.', code, message);
+};

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -8,13 +8,13 @@ import { SQUATTED,
 
 /**
  * Sends command to board LED to flash room status color.
- * @param {string} roomStatus Status of room.
+ * Does nothing --dd flag is set at runtime.
+ * @param {string} room Status of room.
  * @param {object} accessories Board accessories object.
  * @returns {undefined}
  */
-export const flashNotifications = (roomStatus, accessories) => {
-  // TODO better handling of no reservations left
-  if (!roomStatus) {
+export const flashNotifications = (room, accessories) => {
+  if (process.env.DISABLE_DEVICES) {
     return;
   }
 
@@ -30,5 +30,5 @@ export const flashNotifications = (roomStatus, accessories) => {
     [BOOKED]: () => flash.occupied(accessories.led)
   };
 
-  handleFlash[roomStatus.alert || VACANT]();
+  handleFlash[room.alert || VACANT]();
 };


### PR DESCRIPTION
* Enables full client features when running with `--dd` (disable devices).

* Adds `.bithoundrc` to silence alerts about [unused dependencies that are actually used](http://blog.bithound.io/configuring-bithound-101/).