### PR TITLE
Clients reducer

### DIFF
--- a/server/controllers/devices.js
+++ b/server/controllers/devices.js
@@ -17,11 +17,11 @@ import { registerBoard,
          logBoardReady,
          logBoardWarning,
          logBoardFailure } from '../utils';
-import { EMIT_INIT_SOCKETS,
-         FETCH_ROOM_RESERVATIONS,
+import { EMIT_INIT_SOCKETS } from '../ducks/clients';
+import { FETCH_ROOM_RESERVATIONS,
          FETCH_ROOM_TEMPERATURE,
          FETCH_ROOM_MOTION } from '../ducks/rooms';
-import { HANDSHAKE, CHECK_INTERVAL } from '../constants';
+import { CHECK_INTERVAL } from '../constants';
 
 const devicesController = {
   getRooms() {
@@ -38,7 +38,6 @@ const devicesController = {
   initialize() {
     store.dispatch({
       type: EMIT_INIT_SOCKETS,
-      event: HANDSHAKE,
       publicConfig: config.public
     });
 

--- a/server/controllers/devices.js
+++ b/server/controllers/devices.js
@@ -17,7 +17,7 @@ import { registerBoard,
          logBoardReady,
          logBoardWarning,
          logBoardFailure } from '../utils';
-import { EMIT_INIT_DEVICES,
+import { EMIT_INIT_SOCKETS,
          FETCH_ROOM_RESERVATIONS,
          FETCH_ROOM_TEMPERATURE,
          FETCH_ROOM_MOTION } from '../ducks/rooms';
@@ -25,9 +25,11 @@ import { CHECK_INTERVAL } from '../constants';
 
 const devicesController = {
   initialize() {
-    store.dispatch({ type: EMIT_INIT_DEVICES });
+    const rooms = devicesController.getRooms();
 
-    devicesController.getRooms().map((room) => {
+    store.dispatch({ type: EMIT_INIT_SOCKETS, rooms });
+
+    rooms.map((room) => {
       if (process.env.DISABLE_DEVICES) {
         /**
          * If devices are disabled, fetch reservations earlier

--- a/server/controllers/devices.js
+++ b/server/controllers/devices.js
@@ -21,11 +21,26 @@ import { EMIT_INIT_SOCKETS,
          FETCH_ROOM_RESERVATIONS,
          FETCH_ROOM_TEMPERATURE,
          FETCH_ROOM_MOTION } from '../ducks/rooms';
-import { CHECK_INTERVAL } from '../constants';
+import { HANDSHAKE, CHECK_INTERVAL } from '../constants';
 
 const devicesController = {
+  getRooms() {
+    const { rooms } = store.getState().roomsReducer;
+
+    return rooms;
+  },
+
+  /**
+   * Kicks off setting up and connecting to devices.
+   * If devices are disabled, fetches reservations early without starting devices.
+   * @returns {undefined}
+   */
   initialize() {
-    store.dispatch({ type: EMIT_INIT_SOCKETS });
+    store.dispatch({
+      type: EMIT_INIT_SOCKETS,
+      event: HANDSHAKE,
+      publicConfig: config.public
+    });
 
     devicesController.getRooms().map((room) => {
       if (process.env.DISABLE_DEVICES) {
@@ -46,6 +61,14 @@ const devicesController = {
     });
   },
 
+  /**
+   * Top-level scope for handling an individual room's
+   *  board accessories and reservations.
+   * Kicks off actions to monitor accessory states, updating server state as necessary.
+   * @param {object} board JohnnyFive board object.
+   * @param {object} room Corresponding room object.
+   * @returns {undefined}
+   */
   connectToRoom(board, room) {
     logBoardReady(board);
 
@@ -85,12 +108,6 @@ const devicesController = {
         clearInterval(monitorRoomReservations);
       }
     }, CHECK_INTERVAL);
-  },
-
-  getRooms() {
-    const { rooms } = store.getState().roomsReducer;
-
-    return rooms;
   }
 };
 

--- a/server/controllers/devices.js
+++ b/server/controllers/devices.js
@@ -25,11 +25,9 @@ import { CHECK_INTERVAL } from '../constants';
 
 const devicesController = {
   initialize() {
-    const rooms = devicesController.getRooms();
+    store.dispatch({ type: EMIT_INIT_SOCKETS });
 
-    store.dispatch({ type: EMIT_INIT_SOCKETS, rooms });
-
-    rooms.map((room) => {
+    devicesController.getRooms().map((room) => {
       if (process.env.DISABLE_DEVICES) {
         /**
          * If devices are disabled, fetch reservations earlier

--- a/server/ducks/clients.js
+++ b/server/ducks/clients.js
@@ -1,0 +1,41 @@
+/* eslint default-case:0, no-case-declarations:0 */
+import immutable from 'immutable';
+
+import socketController from '../controllers/socket';
+
+import { getOrigin } from '../utils';
+
+export const EMIT_INIT_SOCKETS = 'EMIT_INIT_SOCKETS';
+export const EMIT_CLIENT_CONNECTED = 'EMIT_CLIENT_CONNECTED';
+export const EMIT_FLUSH_CLIENT = 'EMIT_FLUSH_CLIENT';
+
+const initialState = immutable.fromJS({
+  clients: {}
+});
+
+const clientsReducer = (state = initialState, action) => {
+  const reducers = {
+    [EMIT_INIT_SOCKETS]() {
+      socketController.open();
+
+      return state;
+    },
+
+    [EMIT_CLIENT_CONNECTED]() {
+      const { client, anchor } = action;
+      const clientWithAnchor = Object.assign(client, { anchor });
+
+      return state.mergeIn(['clients'], { [getOrigin(client)]: clientWithAnchor });
+    },
+
+    [EMIT_FLUSH_CLIENT]() {
+      const { client } = action;
+
+      return state.deleteIn(['clients', getOrigin(client)]);
+    }
+  };
+
+  return reducers[action.type] ? reducers[action.type]() : state;
+};
+
+export default clientsReducer;

--- a/server/ducks/clients.js
+++ b/server/ducks/clients.js
@@ -3,6 +3,7 @@ import immutable from 'immutable';
 
 import socketController from '../controllers/socket';
 
+import { HANDSHAKE } from '../constants';
 import { getWebSocketKey } from '../utils';
 
 export const EMIT_INIT_SOCKETS = 'EMIT_INIT_SOCKETS';
@@ -16,9 +17,9 @@ const initialState = immutable.fromJS({
 const clientsReducer = (state = initialState, action) => {
   const reducers = {
     [EMIT_INIT_SOCKETS]() {
-      const { event, publicConfig } = action;
+      const { publicConfig } = action;
 
-      socketController.open(event, publicConfig);
+      socketController.open(HANDSHAKE, publicConfig);
 
       return state;
     },

--- a/server/ducks/clients.js
+++ b/server/ducks/clients.js
@@ -3,7 +3,7 @@ import immutable from 'immutable';
 
 import socketController from '../controllers/socket';
 
-import { getOrigin } from '../utils';
+import { getWebSocketKey } from '../utils';
 
 export const EMIT_INIT_SOCKETS = 'EMIT_INIT_SOCKETS';
 export const EMIT_CLIENT_CONNECTED = 'EMIT_CLIENT_CONNECTED';
@@ -16,7 +16,9 @@ const initialState = immutable.fromJS({
 const clientsReducer = (state = initialState, action) => {
   const reducers = {
     [EMIT_INIT_SOCKETS]() {
-      socketController.open();
+      const { event, publicConfig } = action;
+
+      socketController.open(event, publicConfig);
 
       return state;
     },
@@ -25,13 +27,13 @@ const clientsReducer = (state = initialState, action) => {
       const { client, anchor } = action;
       const clientWithAnchor = Object.assign(client, { anchor });
 
-      return state.mergeIn(['clients'], { [getOrigin(client)]: clientWithAnchor });
+      return state.mergeIn(['clients'], { [getWebSocketKey(client)]: clientWithAnchor });
     },
 
     [EMIT_FLUSH_CLIENT]() {
       const { client } = action;
 
-      return state.deleteIn(['clients', getOrigin(client)]);
+      return state.deleteIn(['clients', getWebSocketKey(client)]);
     }
   };
 

--- a/server/ducks/index.js
+++ b/server/ducks/index.js
@@ -1,7 +1,9 @@
+import clientsReducer from './clients';
 import roomsReducer from './rooms';
 import markersReducer from './markers';
 
 export default {
+  clientsReducer,
   roomsReducer,
   markersReducer
 };

--- a/server/ducks/markers.js
+++ b/server/ducks/markers.js
@@ -8,9 +8,7 @@ import { INITIALIZE_MARKERS } from '../constants';
 export const EMIT_SEND_MARKERS = 'EMIT_SEND_MARKERS';
 
 const markersReducer = (state = markers, action) => {
-  const { type } = action;
-
-  switch (type) {
+  switch (action.type) {
     case EMIT_CLIENT_CONNECTED:
       socketController.handle(INITIALIZE_MARKERS, state, action.client);
       break;

--- a/server/ducks/rooms.js
+++ b/server/ducks/rooms.js
@@ -11,13 +11,13 @@ import { flashNotifications,
 import { INITIALIZE_ROOMS,
          ROOM_TEMPERATURE_UPDATE,
          ROOM_STATUSES_UPDATE } from '../constants';
+import { EMIT_CLIENT_CONNECTED } from './clients';
 
-export const EMIT_CLIENT_CONNECTED = 'EMIT_CLIENT_CONNECTED';
 export const MOCK_ROOM_RESERVATIONS = 'MOCK_ROOM_RESERVATIONS';
 export const FETCH_ROOM_TEMPERATURE = 'FETCH_ROOM_TEMPERATURE';
 export const FETCH_ROOM_MOTION = 'FETCH_ROOM_MOTION';
 export const EMIT_ROOM_STATUSES_UPDATE = 'EMIT_ROOM_STATUSES_UPDATE';
-export const EMIT_INIT_DEVICES = 'EMIT_INIT_DEVICES';
+export const EMIT_INIT_SOCKETS = 'EMIT_INIT_SOCKETS';
 export const EMIT_ROOM_PING_RECEIVED = 'EMIT_ROOM_PING_RECEIVED';
 export const EMIT_ROOM_TEMPERATURE_UPDATE = 'EMIT_ROOM_TEMPERATURE_UPDATE';
 export const EMIT_ROOM_MOTION_UPDATE = 'EMIT_ROOM_MOTION_UPDATE';
@@ -31,10 +31,6 @@ const roomsReducer = (state = initialState, action) => {
   let alertChanged = false;
 
   switch (action.type) {
-    case EMIT_INIT_DEVICES:
-      socketController.open(ROOM_STATUSES_UPDATE, secureRooms(state.rooms));
-
-      break;
     case EMIT_CLIENT_CONNECTED:
       socketController.handle(INITIALIZE_ROOMS, secureRooms(state.rooms), action.client);
 

--- a/server/ducks/rooms.js
+++ b/server/ducks/rooms.js
@@ -27,6 +27,7 @@ const initialState = {
   rooms: devices
 };
 
+// TODO integrate with Immutable here, clean up logic.
 const roomsReducer = (state = initialState, action) => {
   let alertChanged = false;
 

--- a/server/ducks/rooms.js
+++ b/server/ducks/rooms.js
@@ -17,17 +17,16 @@ export const MOCK_ROOM_RESERVATIONS = 'MOCK_ROOM_RESERVATIONS';
 export const FETCH_ROOM_TEMPERATURE = 'FETCH_ROOM_TEMPERATURE';
 export const FETCH_ROOM_MOTION = 'FETCH_ROOM_MOTION';
 export const EMIT_ROOM_STATUSES_UPDATE = 'EMIT_ROOM_STATUSES_UPDATE';
-export const EMIT_INIT_SOCKETS = 'EMIT_INIT_SOCKETS';
 export const EMIT_ROOM_PING_RECEIVED = 'EMIT_ROOM_PING_RECEIVED';
 export const EMIT_ROOM_TEMPERATURE_UPDATE = 'EMIT_ROOM_TEMPERATURE_UPDATE';
 export const EMIT_ROOM_MOTION_UPDATE = 'EMIT_ROOM_MOTION_UPDATE';
 export const EMIT_CLEAR_CONNECTION_ERRORS = 'EMIT_CLEAR_CONNECTION_ERRORS';
 
+// TODO Wrap state in Immutable object.
 const initialState = {
   rooms: devices
 };
 
-// TODO integrate with Immutable here, clean up logic.
 const roomsReducer = (state = initialState, action) => {
   let alertChanged = false;
 

--- a/server/utils/logging.js
+++ b/server/utils/logging.js
@@ -20,6 +20,7 @@ const winstonLogger = new winston.Logger({
   transports: [
     new winston.transports.Console({
       level: 'debug',
+      humanReadableUnhandledException: true,
       handleExceptions: true,
       json: false,
       colorize: true

--- a/server/utils/traversals.js
+++ b/server/utils/traversals.js
@@ -14,4 +14,4 @@ export const getHost = (req) => get(req, 'headers.host').slice(0, hostPort);
  * @param {object} client WebSocket client object.
  * @returns {string} Origin parameter.
  */
-export const getOrigin = (client) => get(client, 'upgradeReq.headers.sec-websocket-key');
+export const getWebSocketKey = (client) => get(client, 'upgradeReq.headers.sec-websocket-key');

--- a/tests/server/utils/traversals.spec.js
+++ b/tests/server/utils/traversals.spec.js
@@ -2,7 +2,7 @@
 /* eslint no-magic-numbers:0 max-nested-callbacks:0 */
 import expect from 'expect';
 
-import { getHost, getOrigin } from 'utils';
+import { getHost, getWebSocketKey } from 'utils';
 
 describe('Traversal utilities', () => {
   describe('getHost', () => {
@@ -17,7 +17,7 @@ describe('Traversal utilities', () => {
     });
   });
 
-  describe('getOrigin', () => {
+  describe('getWebSocketKey', () => {
     const mockClient = {
       upgradeReq: {
         headers: {
@@ -27,7 +27,7 @@ describe('Traversal utilities', () => {
     };
 
     it('should return parsed origin name.', () => {
-      expect(getOrigin(mockClient)).toEqual('isNotSteam');
+      expect(getWebSocketKey(mockClient)).toEqual('isNotSteam');
     });
   });
 });


### PR DESCRIPTION
Ripped out in-scope handling of client `ws` objects within `socketController` and moved all the logic to a new `clientsReducer`. Also, eliminated some unnecessary/redundant socket traffic.