### PR TITLE
Bugfix and more robust motion alert

### DIFF
--- a/server/constants/values.js
+++ b/server/constants/values.js
@@ -12,6 +12,7 @@ export const THERMO_FREQ = 10000; // milliseconds
 
 export const HCSR501 = 'HCSR501';
 export const MOTION_PIN = 'A0';
+export const MOTION_FREQ = 1000; // milliseconds
 
 export const CHECK_INTERVAL = 2000;
 export const SPINNER_DELAY = 3000;

--- a/server/ducks/rooms.js
+++ b/server/ducks/rooms.js
@@ -43,7 +43,7 @@ const roomsReducer = (state = initialState, action) => {
       break;
     case EMIT_ROOM_MOTION_UPDATE:
       state.rooms.map((room) => {
-        if (room.id === action.room.id) {
+        if (room.id === action.room.id && action.motion) {
           room.motion = action.motion;
         }
 
@@ -57,7 +57,7 @@ const roomsReducer = (state = initialState, action) => {
           const accessories = room.accessories || action.accessories;
           const reservations = room.reservations || action.reservations;
           const filteredReservations = filterExpiredReservations(reservations);
-          const alert = getRoomAlert(filteredReservations, room.motion);
+          const alert = getRoomAlert(filteredReservations, action.motion || room.motion);
 
           if (room.alert !== alert) {
             alertChanged = true;
@@ -70,7 +70,9 @@ const roomsReducer = (state = initialState, action) => {
             room.reservations = action.reservations;
           }
 
-          flashNotifications(room, accessories);
+          if (accessories) {
+            flashNotifications(room, accessories);
+          }
         }
         return room;
       });

--- a/server/middleware/fetch-room-motion.js
+++ b/server/middleware/fetch-room-motion.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import { EMIT_ROOM_MOTION_UPDATE } from '../ducks/rooms';
 
 const fetchRoomMotion = (next, action) => {
@@ -8,15 +10,14 @@ const fetchRoomMotion = (next, action) => {
     next({
       type: EMIT_ROOM_MOTION_UPDATE,
       room,
-      motion: true
+      motion: moment()
     });
   });
 
-  motion.on('motionend', () => {
+  motion.on('data', () => {
     next({
       type: EMIT_ROOM_MOTION_UPDATE,
-      room,
-      motion: false
+      room
     });
   });
 };

--- a/server/utils/hardware.js
+++ b/server/utils/hardware.js
@@ -10,7 +10,8 @@ import { RGB_PINS,
          THERMO_PIN,
          THERMO_FREQ,
          HCSR501,
-         MOTION_PIN } from '../constants';
+         MOTION_PIN,
+         MOTION_FREQ } from '../constants';
 
 export const registerBoard = (device) => (
   new Board({
@@ -52,6 +53,7 @@ export const registerMotion = (board) => (
     controller: HCSR501,
     pin: MOTION_PIN,
     id: board.id,
+    freq: MOTION_FREQ,
     board
   })
 );

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -13,7 +13,7 @@ import { SQUATTED,
  * @param {object} accessories Board accessories object.
  * @returns {undefined}
  */
-export const flashNotifications = (room, accessories) => {
+export const flashNotifications = (room, accessories = {}) => {
   if (process.env.DISABLE_DEVICES) {
     return;
   }

--- a/server/utils/rooms.js
+++ b/server/utils/rooms.js
@@ -16,13 +16,17 @@ import {
  * @param {array} reservations Array of reservation objects.
  * @returns {string} Room reservation alert.
  */
-export const getRoomAlert = (reservations = [], hasRecentMotion) => {
+export const getRoomAlert = (reservations = [], recentMotion) => {
   const firstMeeting = reservations[0];
   const secondMeeting = reservations[1];
+  const noReservations = !reservations.length;
+  const hasRecentMotion = recentMotion ?
+    recentMotion.isAfter(moment().subtract(5, 'seconds')) : false;
 
-  if (!reservations.length) {
-    // No reservations left for today
+  if (noReservations && !hasRecentMotion) {
     return VACANT;
+  } else if (noReservations && hasRecentMotion) {
+    return SQUATTED;
   }
 
   // Advanced reservation conditions

--- a/tests/server/utils/rooms.spec.js
+++ b/tests/server/utils/rooms.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env node, mocha */
 /* eslint no-magic-numbers:0 max-nested-callbacks:0 */
 import expect from 'expect';
+import moment from 'moment';
 import sinon from 'sinon';
 
 import { filterExpiredReservations,
@@ -89,7 +90,7 @@ describe('Room utilities (server)', () => {
     ];
 
     const clock = (time) => sinon.useFakeTimers(Date.parse(time), 'Date');
-    const hasActiveMotion = true;
+    const hasActiveMotion = moment();
     const hasNoActiveMotion = false;
 
     beforeEach(() => {


### PR DESCRIPTION
"Squatted" alert is now set by determining if the last detected motion started 5 seconds ago or less. `motiondata` is used to constantly poll motion data and recheck the most recent time of detected motion. Bit hacky, but it works.

Also, fixed a bug where a room was marked as "Vacant" if had 1) no reservations and 2) detected motion.