### PR TITLE
Toggle motion-based UI elements based on whether motion is enabled

### DIFF
--- a/client/components/layout/container.jsx
+++ b/client/components/layout/container.jsx
@@ -39,6 +39,7 @@ const mapStateToProps = ({ layoutReducer }) => ({
   markers: layoutReducer.get('markers'),
   displayLegend: layoutReducer.get('displayLegend'),
   displayTemp: layoutReducer.get('displayTemp'),
+  enableMotion: layoutReducer.get('enableMotion'),
   unitOfTemp: layoutReducer.get('unitOfTemp')
 });
 

--- a/client/components/layout/controller.jsx
+++ b/client/components/layout/controller.jsx
@@ -84,7 +84,7 @@ class LayoutController extends Component {
   }
 
   render() {
-    const { meetingRooms, displayLegend, params, location } = this.props;
+    const { meetingRooms, displayLegend, params, location, enableMotion } = this.props;
     const locationKeys = pluckLocations(meetingRooms);
 
     const renderLocation = (locationKey, index) => (
@@ -105,6 +105,7 @@ class LayoutController extends Component {
           </SwipeableViews>
           <MapLegend
             enabled={displayLegend}
+            enableMotion={enableMotion}
             showYouAreHere={hasAnchor(location)}/>
         </Paper>
         <DisplayError {...this.props}/>
@@ -120,6 +121,7 @@ LayoutController.propTypes = {
   markers: PropTypes.array,
   displayLegend: PropTypes.bool.isRequired,
   displayTemp: PropTypes.bool.isRequired,
+  enableMotion: PropTypes.bool.isRequired,
   unitOfTemp: PropTypes.string.isRequired,
   params: PropTypes.shape({
     location: PropTypes.string

--- a/client/components/layout/map-legend.jsx
+++ b/client/components/layout/map-legend.jsx
@@ -9,7 +9,7 @@ import { applyStyles } from '../../config/composition';
 import { STATUS_COLORS } from '../../constants';
 import { styles } from './styles';
 
-const MapLegend = ({ showYouAreHere, enabled }) => {
+const MapLegend = ({ showYouAreHere, enabled, enableMotion }) => {
   if (!enabled) {
     return null;
   }
@@ -51,12 +51,12 @@ const MapLegend = ({ showYouAreHere, enabled }) => {
           leftAvatar={getIcon(STATUS_COLORS.BOOKED)}>
             Booked
         </ListItem>
-        <ListItem
+        {enableMotion ? <ListItem
           style={styles.mapLegendItem}
           disabled={true}
           leftAvatar={getIcon(STATUS_COLORS.SQUATTED)}>
             Occupied, no reservation
-        </ListItem>
+        </ListItem> : null}
         <ListItem
           style={styles.mapLegendItem}
           disabled={true}
@@ -82,7 +82,8 @@ const MapLegend = ({ showYouAreHere, enabled }) => {
 
 MapLegend.propTypes = {
   enabled: PropTypes.bool,
-  showYouAreHere: PropTypes.bool.isRequired
+  showYouAreHere: PropTypes.bool.isRequired,
+  enableMotion: PropTypes.bool.isRequired
 };
 
 export default applyStyles(MapLegend);

--- a/client/ducks/layout.js
+++ b/client/ducks/layout.js
@@ -58,18 +58,20 @@ const initialState = immutable.fromJS({
   stalls: null,
   displayLegend: true,
   displayTemp: true, // User UI option for toggling temperature display on map
-  enableTemp: false, // Server variable that governs display of temperature UI elements
+  enableTemp: false, // Server variable that governs display of temperature features
+  enableMotion: false, // Server variable that governs display of motion features
   unitOfTemp: FAHRENHEIT
 });
 
 const layoutReducer = (state = initialState, action) => {
   const reducers = {
     [EMIT_HANDSHAKE_RECEIVED]() {
-      const { enableTemperature, defaultTempScale } = action.config;
+      const { enableTemperature, enableMotion, defaultTempScale } = action.config;
 
       return state
         .set('enableTemp', enableTemperature || false)
-        .set('unitOfTemp', defaultTempScale || FAHRENHEIT);
+        .set('unitOfTemp', defaultTempScale || FAHRENHEIT)
+        .set('enableMotion', enableMotion || false);
     },
 
     [EMIT_ROOM_STATUSES_UPDATE]() {


### PR DESCRIPTION
"Occupied, no reservation" is hidden from the map legend when motion sensors are disabled.